### PR TITLE
fix(scriptappy-from-jsdoc): sort child entries

### DIFF
--- a/packages/scriptappy-from-jsdoc/src/transformer.js
+++ b/packages/scriptappy-from-jsdoc/src/transformer.js
@@ -46,6 +46,12 @@ function printViolations(violations, logger = console) {
   return errs;
 }
 
+function sortAlphabetically(a, b) {
+  const aa = a.toLowerCase();
+  const bb = b.toLowerCase();
+  return aa > bb ? 1 : (bb > aa ? -1 : 0); // eslint-disable-line
+}
+
 function logRule(cfg, doc, rule, message, violations) {
   const r = cfg.parse.rules[rule];
   const severity = +r;
@@ -200,11 +206,7 @@ function checkTypes(obj, priv, cfg) {
 function transform({ ids, priv }, cfg) {
   const entries = {};
   const definitions = {};
-  Object.keys(ids).sort((a, b) => {
-    const aa = a.toLowerCase();
-    const bb = b.toLowerCase();
-    return aa > bb ? 1 : (bb > aa ? -1 : 0); // eslint-disable-line
-  }).forEach(longname => {
+  Object.keys(ids).sort(sortAlphabetically).forEach(longname => {
     ids[longname].forEach((d, idx) => {
       // const d = ids[longname];
       const pr = priv[longname][idx];
@@ -229,6 +231,14 @@ function transform({ ids, priv }, cfg) {
 
       if (access === 'private') {
         return;
+      }
+
+      if (typeof d.entries === 'object') {
+        const sortedEntries = {};
+        Object.keys(d.entries).sort(sortAlphabetically).forEach((key) => {
+          sortedEntries[key] = d.entries[key];
+        });
+        d.entries = sortedEntries;
       }
 
       if (parent) {

--- a/packages/scriptappy-from-jsdoc/test/transformer.spec.js
+++ b/packages/scriptappy-from-jsdoc/test/transformer.spec.js
@@ -378,6 +378,82 @@ describe('transform', () => {
       },
     });
   });
+
+  it('should sort entries alphabetically', () => {
+    const { entries } = t.transform({
+      ids: {
+        B: [{
+          entries: {
+            d: { type: 'object' },
+            c: { type: 'object' },
+          },
+        }],
+        'B.d': [{ description: 'd', entries: {} }],
+        'B.c': [{ description: 'c', entries: {} }],
+        A: [{
+          entries: {
+            b: { type: 'object' },
+            a: { type: 'object' },
+          },
+        }],
+        'A.b': [{ description: 'b', entries: {} }],
+        'A.a': [{ description: 'a', entries: {} }],
+      },
+      priv: {
+        A: [{ __id: 'A', __isEntry: true }],
+        'A.b': [{ __scopeName: 'b', __memberOf: 'A' }],
+        'A.a': [{ __scopeName: 'a', __memberOf: 'A' }],
+        B: [{ __id: 'B', __isEntry: true }],
+        'B.d': [{ __scopeName: 'd', __memberOf: 'B' }],
+        'B.c': [{ __scopeName: 'c', __memberOf: 'B' }],
+      },
+    }, cfg);
+
+    const topKeys = Object.keys(entries);
+    const childKeys = [];
+    topKeys.forEach(key => childKeys.push(...Object.keys(entries[key].entries)));
+
+    expect(topKeys).to.eql(['A', 'B'], 'top level entries');
+    expect(childKeys).to.eql(['a', 'b', 'c', 'd'], 'child entries');
+  });
+
+  it('should sort definitions alphabetically', () => {
+    const { definitions } = t.transform({
+      ids: {
+        B: [{
+          entries: {
+            d: { type: 'object' },
+            c: { type: 'object' },
+          },
+        }],
+        'B.d': [{ description: 'd', entries: {} }],
+        'B.c': [{ description: 'c', entries: {} }],
+        A: [{
+          entries: {
+            b: { type: 'object' },
+            a: { type: 'object' },
+          },
+        }],
+        'A.b': [{ description: 'b', entries: {} }],
+        'A.a': [{ description: 'a', entries: {} }],
+      },
+      priv: {
+        A: [{ __id: 'A' }],
+        'A.b': [{ __scopeName: 'b', __memberOf: 'A' }],
+        'A.a': [{ __scopeName: 'a', __memberOf: 'A' }],
+        B: [{ __id: 'B' }],
+        'B.d': [{ __scopeName: 'd', __memberOf: 'B' }],
+        'B.c': [{ __scopeName: 'c', __memberOf: 'B' }],
+      },
+    }, cfg);
+
+    const topKeys = Object.keys(definitions);
+    const childKeys = [];
+    topKeys.forEach(key => childKeys.push(...Object.keys(definitions[key].entries)));
+
+    expect(topKeys).to.eql(['A', 'B'], 'top level definitions');
+    expect(childKeys).to.eql(['a', 'b', 'c', 'd'], 'child entries of definitions');
+  });
 });
 
 describe('generate', () => {


### PR DESCRIPTION
Makes sure child entries gets sorted alphabetically.