### PR TITLE
feat(ts-dts): improvements to support generating definitions for picasso.js

### DIFF
--- a/packages/to-dts/lib/cli.js
+++ b/packages/to-dts/lib/cli.js
@@ -23,6 +23,11 @@ const toDts = {
         describe: 'Type of export',
         type: 'string',
       },
+      output: {
+        alias: 'o',
+        describe: 'File to write to',
+        type: 'string',
+      },
     });
   },
   handler(argv) {
@@ -33,7 +38,8 @@ const toDts = {
       }
       const spec = fs.readFileSync(p, 'utf-8');
       const typed = parse(JSON.parse(spec), argv);
-      fs.writeFileSync(path.resolve(process.cwd(), 'index.d.ts'), typed, 'utf-8');
+      const output = argv.output || path.resolve(process.cwd(), 'index.d.ts');
+      fs.writeFileSync(output, typed, 'utf-8');
     } else {
       throw new Error('Please provide a spec file');
     }

--- a/packages/to-dts/lib/cli.js
+++ b/packages/to-dts/lib/cli.js
@@ -23,6 +23,10 @@ const toDts = {
         describe: 'Type of export',
         type: 'string',
       },
+      exportConst: {
+        description: 'Create const of generated type to export',
+        type: 'string',
+      },
       output: {
         alias: 'o',
         describe: 'File to write to',

--- a/packages/to-dts/lib/index.js
+++ b/packages/to-dts/lib/index.js
@@ -11,6 +11,7 @@ const top = require('./top');
  * @param {object=} config
  * @param {string=} config.umd
  * @param {('named'|'exports'|'default')=} config.export
+ * @param {string=} config.output
  * @returns {string}
  */
 function toDts(specification, config = {}) {

--- a/packages/to-dts/lib/index.js
+++ b/packages/to-dts/lib/index.js
@@ -11,6 +11,7 @@ const top = require('./top');
  * @param {object=} config
  * @param {string=} config.umd
  * @param {('named'|'exports'|'default')=} config.export
+ * @param {string=} config.exportConst
  * @param {string=} config.output
  * @returns {string}
  */
@@ -26,6 +27,7 @@ function toDts(specification, config = {}) {
   const { types, entriesRoot, entriesFlags, definitionsRoot } = top(specification, {
     umd: config.umd,
     export: config.export,
+    exportConst: config.exportConst,
   });
 
   if (definitionsRoot && definitionsRoot !== entriesRoot) {

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -1,6 +1,6 @@
 const dom = require('dts-dom');
 
-module.exports = function top(spec, { umd = '', export: exp } = {}) {
+module.exports = function top(spec, { umd = '', export: exp, exportConst } = {}) {
   // dom.create.namespace('supernova');
   const types = [];
   let entriesFlags = 0;
@@ -38,7 +38,12 @@ module.exports = function top(spec, { umd = '', export: exp } = {}) {
   // "export default x" is used for es6 modules of type "export default x"
   // "export x" is for named exports
   if (ex === 'default') {
-    types.push(dom.create.exportDefault(libraryName));
+    if (exportConst) {
+      types.push(dom.create.const(exportConst, libraryName));
+      types.push(dom.create.exportDefault(exportConst));
+    } else {
+      types.push(dom.create.exportDefault(libraryName));
+    }
   } else if (ex === 'exports') {
     types.push(dom.create.exportEquals(libraryName));
   } else {

--- a/packages/to-dts/lib/traverse.js
+++ b/packages/to-dts/lib/traverse.js
@@ -52,6 +52,11 @@ function traverseFn(g) {
             tsType.flags = (tsType.flags || 0) | dom.DeclarationFlags.Optional;
           }
           tsParent.members.push(tsType);
+        } else if (tsType.kind === 'object' && def.extends) {
+          const extendsType = g.getType(def.extends[0]);
+          const intersection = dom.create.intersection([extendsType, tsType]);
+          const propType = dom.create.alias(key, intersection, def.optional ? dom.DeclarationFlags.Optional : 0);
+          tsParent.members.push(propType);
         } else if (VALID_MEMBERS[tsParent.kind] && VALID_MEMBERS[tsParent.kind].includes('property')) {
           const propType = dom.create.property(key, tsType, def.optional ? dom.DeclarationFlags.Optional : 0);
           tsParent.members.push(propType);

--- a/packages/to-dts/lib/type.js
+++ b/packages/to-dts/lib/type.js
@@ -73,7 +73,11 @@ function typeFn(g) {
     }
 
     if (def.kind === 'literal') {
-      return dom.type.stringLiteral(def.value);
+      let { value } = def;
+      if (typeof def.value === 'string') {
+        value = value.replace(/'/g, '');
+      }
+      return dom.type.stringLiteral(value);
     }
 
     // ====== types ===========

--- a/packages/to-dts/lib/types/function.js
+++ b/packages/to-dts/lib/types/function.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 const dom = require('dts-dom');
 const params = require('./params');
 
@@ -10,10 +11,29 @@ module.exports = function fn(def, tsParent, g) {
   if (tsParent && ['union', 'array', 'parameter', 'alias'].includes(tsParent.kind)) {
     return dom.create.functionType(par, ret);
   }
+  if (def.entries) {
+    const t = dom.create.objectType([]);
+    const cs = dom.create.callSignature(par, ret);
+
+    // optional/rest flags for params in call-signatures are NOT printed by dts-dom,
+    // so hack it a bit by ammending ... or ? to the name of the param to get the same effect
+    // TODO - remove this hack when dts-dom fixes this
+    cs.parameters.forEach(p => {
+      if ((p.flags || 0) & dom.ParameterFlags.Optional) {
+        p.name += '?';
+      } else if (p.flags === dom.ParameterFlags.Rest) {
+        p.name = `...${p.name}`;
+      }
+      p.flags = 0; // reset to avoid flags being used if dts-dom supports it before above code has been removed
+    });
+    t.members.push(cs);
+    return t;
+  }
 
   // TODO - async?
   // if (def.optional) {
   //   t.flags = dom.DeclarationFlags.Optional;
   // }
-  return dom.create.function(def.name, par, ret);
+  const fnType = dom.create.functionType(par, ret);
+  return dom.create.alias(def.name, fnType);
 };

--- a/packages/to-dts/test/function.spec.js
+++ b/packages/to-dts/test/function.spec.js
@@ -19,11 +19,15 @@ describe('function', () => {
     params.returns([]);
     const v = fn(def);
     expect(v).to.eql({
-      kind: 'function',
+      kind: 'alias',
       name: 'foo',
       flags: 0,
-      parameters: [],
-      returnType: 'void',
+      type: {
+        kind: 'function-type',
+        parameters: [],
+        returnType: 'void',
+        typeParameters: [],
+      },
       typeParameters: [],
     });
   });
@@ -54,7 +58,7 @@ describe('function', () => {
     params.returns(['p']);
     const v = fn(def, {}, 'g');
     expect(params).to.have.been.calledWithExactly('par', 'self', 'g');
-    expect(v.parameters).to.eql(['p']);
+    expect(v.type.parameters).to.eql(['p']);
   });
 
   it('should have a return type', () => {
@@ -65,7 +69,7 @@ describe('function', () => {
       getType: sandbox.stub(),
     };
     g.getType.withArgs('ret').returns('animal');
-    expect(fn(def, {}, g).returnType).to.eql('animal');
+    expect(fn(def, {}, g).type.returnType).to.eql('animal');
   });
 
   it('should write definition', () => {
@@ -77,6 +81,6 @@ describe('function', () => {
     params.withArgs('par').returns([dom.create.parameter('first', dom.type.boolean)]);
     const v = fn(def, {}, g);
     const s = dom.emit(v, { rootFlags: 1 });
-    expect(s.trimRight()).to.equal('function meh(first: boolean): string;');
+    expect(s.trimRight()).to.equal('type meh = (first: boolean)=>string;');
   });
 });

--- a/packages/to-dts/test/index.spec.js
+++ b/packages/to-dts/test/index.spec.js
@@ -28,7 +28,7 @@ describe('to-dts', () => {
     typeFn.withArgs({ specification: 'spec' }).returns('getT');
     traverseFn.withArgs({ specification: 'spec', getType: 'getT' }).returns(trav);
 
-    top.withArgs('spec', { umd: undefined, export: undefined }).returns({
+    top.withArgs('spec', { umd: undefined, export: undefined, exportConst: undefined }).returns({
       types: [],
     });
 
@@ -46,7 +46,7 @@ describe('to-dts', () => {
   it('should return entries', () => {
     const spec = { entries: 'entr' };
 
-    top.withArgs(spec, { umd: undefined, export: undefined }).returns({
+    top.withArgs(spec, { umd: undefined, export: undefined, exportConst: undefined }).returns({
       types: [],
       entriesRoot: 'p',
       entriesFlags: 16,
@@ -65,7 +65,7 @@ describe('to-dts', () => {
   it('should return definitions', () => {
     const spec = { definitions: 'defs' };
 
-    top.withArgs(spec, { umd: undefined, export: undefined }).returns({
+    top.withArgs(spec, { umd: undefined, export: undefined, exportConst: undefined }).returns({
       types: [],
       definitionsRoot: 'defP',
       flags: 0,


### PR DESCRIPTION
### Improvements

#### Functions with properties

Support types which is both a function and have properties. This is for example used by Picasso to support both (1) configuring a picasso instance, and (2) rendering a chart. Example:

```js
// Configure picasso (using it as a function)
const instance = picasso({ config });

// Render a chart (using a property on the function)
const vis = picasso.chart({ ... });
```

#### Type intersections

Support types which extends another type. For example the `ComponentAxis` extends `ComponentSettings`. Settings specified at either level are valid.

```ts
type ComponentAxis = picassojs.ComponentSettings & {
  type: 'axis';
  scale: string;
  settings?: picassojs.ComponentAxis.DiscreteSettings | picassojs.ComponentAxis.ContinuousSettings;
};
``` 

#### Literals

Strip `'` from literals to ensure it becomes `type: 'axis'` (instead of `type: "'axis'"`).

#### Output

Add CLI option to control where output type script definitions are generated.

```
sy to-dts --output ../packages/picasso.js/types/index.d.ts
```

#### Export as const

Add CLI option to control if the exported type should be an instance of the type. The value for the option is the name of the exported const.

```ts
// With --export default
declare type picassojs = { cfg, chart, component, ... };
export default picassojs;

// With --export default --exportConst pjs
declare type picassojs = { cfg, chart, component, ... };
declare const pjs: picassojs;
export default pjs;
```

