### PR TITLE
feat(to-dts): support type which is a function and have properties

### DIFF
--- a/packages/to-dts/lib/types/function.js
+++ b/packages/to-dts/lib/types/function.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 const dom = require('dts-dom');
 const params = require('./params');
 
@@ -10,10 +11,29 @@ module.exports = function fn(def, tsParent, g) {
   if (tsParent && ['union', 'array', 'parameter', 'alias'].includes(tsParent.kind)) {
     return dom.create.functionType(par, ret);
   }
+  if (def.entries) {
+    const t = dom.create.objectType([]);
+    const cs = dom.create.callSignature(par, ret);
+
+    // optional/rest flags for params in call-signatures are NOT printed by dts-dom,
+    // so hack it a bit by ammending ... or ? to the name of the param to get the same effect
+    // TODO - remove this hack when dts-dom fixes this
+    cs.parameters.forEach(p => {
+      if ((p.flags || 0) & dom.ParameterFlags.Optional) {
+        p.name += '?';
+      } else if (p.flags === dom.ParameterFlags.Rest) {
+        p.name = `...${p.name}`;
+      }
+      p.flags = 0; // reset to avoid flags being used if dts-dom supports it before above code has been removed
+    });
+    t.members.push(cs);
+    return t;
+  }
 
   // TODO - async?
   // if (def.optional) {
   //   t.flags = dom.DeclarationFlags.Optional;
   // }
-  return dom.create.function(def.name, par, ret);
+  const fnType = dom.create.functionType(par, ret);
+  return dom.create.alias(def.name, fnType);
 };

--- a/packages/to-dts/test/function.spec.js
+++ b/packages/to-dts/test/function.spec.js
@@ -19,11 +19,15 @@ describe('function', () => {
     params.returns([]);
     const v = fn(def);
     expect(v).to.eql({
-      kind: 'function',
+      kind: 'alias',
       name: 'foo',
       flags: 0,
-      parameters: [],
-      returnType: 'void',
+      type: {
+        kind: 'function-type',
+        parameters: [],
+        returnType: 'void',
+        typeParameters: [],
+      },
       typeParameters: [],
     });
   });
@@ -54,7 +58,7 @@ describe('function', () => {
     params.returns(['p']);
     const v = fn(def, {}, 'g');
     expect(params).to.have.been.calledWithExactly('par', 'self', 'g');
-    expect(v.parameters).to.eql(['p']);
+    expect(v.type.parameters).to.eql(['p']);
   });
 
   it('should have a return type', () => {
@@ -65,7 +69,7 @@ describe('function', () => {
       getType: sandbox.stub(),
     };
     g.getType.withArgs('ret').returns('animal');
-    expect(fn(def, {}, g).returnType).to.eql('animal');
+    expect(fn(def, {}, g).type.returnType).to.eql('animal');
   });
 
   it('should write definition', () => {
@@ -77,6 +81,6 @@ describe('function', () => {
     params.withArgs('par').returns([dom.create.parameter('first', dom.type.boolean)]);
     const v = fn(def, {}, g);
     const s = dom.emit(v, { rootFlags: 1 });
-    expect(s.trimRight()).to.equal('function meh(first: boolean): string;');
+    expect(s.trimRight()).to.equal('type meh = (first: boolean)=>string;');
   });
 });


### PR DESCRIPTION
Support types which is both a function and have properties.

This is for example used by Picasso to support both (1) configuring a picasso instance, and (2) rendering a chart. Example:

```js
// Configure picasso (using it as a function)
const instance = picasso({ config });

// Render a chart (using a property on the function)
const vis = picasso.chart({ ... });
```