### PR TITLE
feat(to-dts): support type intersections

### DIFF
--- a/packages/to-dts/lib/traverse.js
+++ b/packages/to-dts/lib/traverse.js
@@ -52,6 +52,11 @@ function traverseFn(g) {
             tsType.flags = (tsType.flags || 0) | dom.DeclarationFlags.Optional;
           }
           tsParent.members.push(tsType);
+        } else if (tsType.kind === 'object' && def.extends) {
+          const extendsType = g.getType(def.extends[0]);
+          const intersection = dom.create.intersection([extendsType, tsType]);
+          const propType = dom.create.alias(key, intersection, def.optional ? dom.DeclarationFlags.Optional : 0);
+          tsParent.members.push(propType);
         } else if (VALID_MEMBERS[tsParent.kind] && VALID_MEMBERS[tsParent.kind].includes('property')) {
           const propType = dom.create.property(key, tsType, def.optional ? dom.DeclarationFlags.Optional : 0);
           tsParent.members.push(propType);

--- a/packages/to-dts/test/traverse.spec.js
+++ b/packages/to-dts/test/traverse.spec.js
@@ -237,5 +237,28 @@ describe('traverse', () => {
         ]);
       });
     });
+
+    it('should use type insection for type inheritance', () => {
+      const tsParent = { kind: 'namespace', members: [] };
+      const def = { kind: 'object', extends: [{ type: '/animal' }] };
+      g.getType.withArgs({ name: 'mammoth', path: '/mammoth', ...def }).returns({ kind: 'object', name: 'mammoth' });
+      g.getType.withArgs({ type: '/animal' }).returns({ kind: 'object', name: 'animal' });
+      traverse({ mammoth: def }, { parent: tsParent, path: '' });
+      expect(tsParent.members).to.eql([
+        {
+          kind: 'alias',
+          name: 'mammoth',
+          type: {
+            kind: 'intersection',
+            members: [
+              { kind: 'object', name: 'animal' },
+              { kind: 'object', name: 'mammoth' },
+            ],
+          },
+          typeParameters: [],
+          flags: 0,
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Support types which extends another type. For example when `ComponentAxis` extends `ComponentSettings` the settings specified in both supertype or subtype are valid.

```ts
type ComponentAxis = picassojs.ComponentSettings & {
  type: 'axis';
  scale: string;
  settings?: picassojs.ComponentAxis.DiscreteSettings | picassojs.ComponentAxis.ContinuousSettings;
};
``` 