### PR TITLE
feat(to-dts): add output and exportConst as cli options

### DIFF
--- a/packages/to-dts/lib/cli.js
+++ b/packages/to-dts/lib/cli.js
@@ -23,6 +23,11 @@ const toDts = {
         describe: 'Type of export',
         type: 'string',
       },
+      output: {
+        alias: 'o',
+        describe: 'File to write to',
+        type: 'string',
+      },
     });
   },
   handler(argv) {
@@ -33,7 +38,8 @@ const toDts = {
       }
       const spec = fs.readFileSync(p, 'utf-8');
       const typed = parse(JSON.parse(spec), argv);
-      fs.writeFileSync(path.resolve(process.cwd(), 'index.d.ts'), typed, 'utf-8');
+      const output = argv.output || path.resolve(process.cwd(), 'index.d.ts');
+      fs.writeFileSync(output, typed, 'utf-8');
     } else {
       throw new Error('Please provide a spec file');
     }

--- a/packages/to-dts/lib/cli.js
+++ b/packages/to-dts/lib/cli.js
@@ -23,6 +23,10 @@ const toDts = {
         describe: 'Type of export',
         type: 'string',
       },
+      exportConst: {
+        description: 'Create const of generated type to export',
+        type: 'string',
+      },
       output: {
         alias: 'o',
         describe: 'File to write to',

--- a/packages/to-dts/lib/index.js
+++ b/packages/to-dts/lib/index.js
@@ -11,6 +11,7 @@ const top = require('./top');
  * @param {object=} config
  * @param {string=} config.umd
  * @param {('named'|'exports'|'default')=} config.export
+ * @param {string=} config.output
  * @returns {string}
  */
 function toDts(specification, config = {}) {

--- a/packages/to-dts/lib/index.js
+++ b/packages/to-dts/lib/index.js
@@ -11,6 +11,7 @@ const top = require('./top');
  * @param {object=} config
  * @param {string=} config.umd
  * @param {('named'|'exports'|'default')=} config.export
+ * @param {string=} config.exportConst
  * @param {string=} config.output
  * @returns {string}
  */
@@ -26,6 +27,7 @@ function toDts(specification, config = {}) {
   const { types, entriesRoot, entriesFlags, definitionsRoot } = top(specification, {
     umd: config.umd,
     export: config.export,
+    exportConst: config.exportConst,
   });
 
   if (definitionsRoot && definitionsRoot !== entriesRoot) {

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -1,6 +1,6 @@
 const dom = require('dts-dom');
 
-module.exports = function top(spec, { umd = '', export: exp } = {}) {
+module.exports = function top(spec, { umd = '', export: exp, exportConst } = {}) {
   // dom.create.namespace('supernova');
   const types = [];
   let entriesFlags = 0;
@@ -38,7 +38,12 @@ module.exports = function top(spec, { umd = '', export: exp } = {}) {
   // "export default x" is used for es6 modules of type "export default x"
   // "export x" is for named exports
   if (ex === 'default') {
-    types.push(dom.create.exportDefault(libraryName));
+    if (exportConst) {
+      types.push(dom.create.const(exportConst, libraryName));
+      types.push(dom.create.exportDefault(exportConst));
+    } else {
+      types.push(dom.create.exportDefault(libraryName));
+    }
   } else if (ex === 'exports') {
     types.push(dom.create.exportEquals(libraryName));
   } else {

--- a/packages/to-dts/test/index.spec.js
+++ b/packages/to-dts/test/index.spec.js
@@ -28,7 +28,7 @@ describe('to-dts', () => {
     typeFn.withArgs({ specification: 'spec' }).returns('getT');
     traverseFn.withArgs({ specification: 'spec', getType: 'getT' }).returns(trav);
 
-    top.withArgs('spec', { umd: undefined, export: undefined }).returns({
+    top.withArgs('spec', { umd: undefined, export: undefined, exportConst: undefined }).returns({
       types: [],
     });
 
@@ -46,7 +46,7 @@ describe('to-dts', () => {
   it('should return entries', () => {
     const spec = { entries: 'entr' };
 
-    top.withArgs(spec, { umd: undefined, export: undefined }).returns({
+    top.withArgs(spec, { umd: undefined, export: undefined, exportConst: undefined }).returns({
       types: [],
       entriesRoot: 'p',
       entriesFlags: 16,
@@ -65,7 +65,7 @@ describe('to-dts', () => {
   it('should return definitions', () => {
     const spec = { definitions: 'defs' };
 
-    top.withArgs(spec, { umd: undefined, export: undefined }).returns({
+    top.withArgs(spec, { umd: undefined, export: undefined, exportConst: undefined }).returns({
       types: [],
       definitionsRoot: 'defP',
       flags: 0,


### PR DESCRIPTION
#### Output

Add CLI option to control where type script definitions are generated.

```
sy to-dts --output ../packages/picasso.js/types/index.d.ts
```

#### Export as const

Add CLI option to control if the exported type should be an instance of the type. The value for the option is the name of the exported const.

```ts
// Output when running `sy to-dts --export default`
declare type picassojs = { cfg, chart, component, ... };
export default picassojs;

// Output when running `sy to-dts --export default --exportConst pjs`
declare type picassojs = { cfg, chart, component, ... };
declare const pjs: picassojs;
export default pjs;
```