### PR TITLE
fix(to-dts): use double quatation marks for literals

### DIFF
--- a/packages/to-dts/lib/type.js
+++ b/packages/to-dts/lib/type.js
@@ -74,7 +74,7 @@ function typeFn(g) {
 
     if (def.kind === 'literal') {
       let { value } = def;
-      if (typeof def.value === 'string') {
+      if (typeof value === 'string') {
         value = value.replace(/'/g, '');
       }
       return dom.type.stringLiteral(value);

--- a/packages/to-dts/lib/type.js
+++ b/packages/to-dts/lib/type.js
@@ -73,7 +73,11 @@ function typeFn(g) {
     }
 
     if (def.kind === 'literal') {
-      return dom.type.stringLiteral(def.value);
+      let { value } = def;
+      if (typeof def.value === 'string') {
+        value = value.replace(/'/g, '');
+      }
+      return dom.type.stringLiteral(value);
     }
 
     // ====== types ===========

--- a/packages/to-dts/test/type.spec.js
+++ b/packages/to-dts/test/type.spec.js
@@ -153,6 +153,11 @@ describe('type', () => {
     });
   });
 
+  it("should strip single quotes (') from literals", () => {
+    const def = { kind: 'literal', value: "'v'" };
+    expect(getType(def, 'p')).to.eql({ kind: 'string-literal', value: 'v' });
+  });
+
   it('should create function type', () => {
     const def = { type: 'function' };
     g.getType.withArgs('ret').returns('r');


### PR DESCRIPTION
Strip `'` from literals to ensure it becomes `type: 'axis'` (instead of `type: "'axis'"`).