### PR TITLE
feat(to-dts): show comment that content is generated

### DIFF
--- a/packages/to-dts/lib/cli.js
+++ b/packages/to-dts/lib/cli.js
@@ -32,8 +32,8 @@ const toDts = {
         describe: 'File to write to',
         type: 'string',
       },
-      showGeneratedComment: {
-        describe: "Show comment in output file that it's automatically generated",
+      includeDisclaimer: {
+        describe: "Include disclaimer in output file that it's automatically generated",
         type: 'boolean',
         default: true,
       },

--- a/packages/to-dts/lib/cli.js
+++ b/packages/to-dts/lib/cli.js
@@ -32,6 +32,11 @@ const toDts = {
         describe: 'File to write to',
         type: 'string',
       },
+      showGeneratedComment: {
+        describe: "Show comment in output file that it's automatically generated",
+        type: 'boolean',
+        default: true,
+      },
     });
   },
   handler(argv) {

--- a/packages/to-dts/lib/index.js
+++ b/packages/to-dts/lib/index.js
@@ -13,7 +13,7 @@ const top = require('./top');
  * @param {('named'|'exports'|'default')=} config.export
  * @param {string=} config.exportConst
  * @param {string=} config.output
- * @param {boolean=} config.showGeneratedComment
+ * @param {boolean=} config.includeDisclaimer
  * @returns {string}
  */
 function toDts(specification, config) {
@@ -55,7 +55,7 @@ function toDts(specification, config) {
   }
   toEmit.push(...definitions);
 
-  dts += toEmit.map(t => dom.emit(t)).join('');
+  dts += toEmit.map((t) => dom.emit(t)).join('');
 
   return dts;
 }

--- a/packages/to-dts/lib/index.js
+++ b/packages/to-dts/lib/index.js
@@ -13,9 +13,10 @@ const top = require('./top');
  * @param {('named'|'exports'|'default')=} config.export
  * @param {string=} config.exportConst
  * @param {string=} config.output
+ * @param {boolean=} config.showGeneratedComment
  * @returns {string}
  */
-function toDts(specification, config = {}) {
+function toDts(specification, config) {
   let dts = '';
 
   const g = {
@@ -24,11 +25,7 @@ function toDts(specification, config = {}) {
   g.getType = typeFn(g);
   g.traverse = traverseFn(g);
 
-  const { types, entriesRoot, entriesFlags, definitionsRoot } = top(specification, {
-    umd: config.umd,
-    export: config.export,
-    exportConst: config.exportConst,
-  });
+  const { types, entriesRoot, entriesFlags, definitionsRoot } = top(specification, config);
 
   if (definitionsRoot && definitionsRoot !== entriesRoot) {
     g.namespace = definitionsRoot.name;

--- a/packages/to-dts/lib/index.js
+++ b/packages/to-dts/lib/index.js
@@ -55,7 +55,7 @@ function toDts(specification, config) {
   }
   toEmit.push(...definitions);
 
-  dts += toEmit.map((t) => dom.emit(t)).join('');
+  dts += toEmit.map(t => dom.emit(t)).join('');
 
   return dts;
 }

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -32,7 +32,7 @@ module.exports = function top(spec, { umd = '', export: exp, exportConst, includ
       .split('/')
       .reverse()[0]
       .split('.')[0]
-      .replace(/-([A-z0-9])/g, (v) => `${v[1].toUpperCase()}`);
+      .replace(/-([A-z0-9])/g, v => `${v[1].toUpperCase()}`);
     libraryName = n;
   }
 

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -1,6 +1,6 @@
 const dom = require('dts-dom');
 
-module.exports = function top(spec, { umd = '', export: exp, exportConst, showGeneratedComment } = {}) {
+module.exports = function top(spec, { umd = '', export: exp, exportConst, includeDisclaimer } = {}) {
   // dom.create.namespace('supernova');
   const types = [];
   let entriesFlags = 0;
@@ -9,7 +9,7 @@ module.exports = function top(spec, { umd = '', export: exp, exportConst, showGe
   let libraryName;
   let ex = exp || 'named';
 
-  if (showGeneratedComment) {
+  if (includeDisclaimer) {
     types.push('// File generated automatically by "@scriptappy/to-dts"; DO NOT EDIT.');
   }
 
@@ -32,7 +32,7 @@ module.exports = function top(spec, { umd = '', export: exp, exportConst, showGe
       .split('/')
       .reverse()[0]
       .split('.')[0]
-      .replace(/-([A-z0-9])/g, v => `${v[1].toUpperCase()}`);
+      .replace(/-([A-z0-9])/g, (v) => `${v[1].toUpperCase()}`);
     libraryName = n;
   }
 

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -1,6 +1,6 @@
 const dom = require('dts-dom');
 
-module.exports = function top(spec, { umd = '', export: exp, exportConst } = {}) {
+module.exports = function top(spec, { umd = '', export: exp, exportConst, showGeneratedComment } = {}) {
   // dom.create.namespace('supernova');
   const types = [];
   let entriesFlags = 0;
@@ -8,6 +8,10 @@ module.exports = function top(spec, { umd = '', export: exp, exportConst } = {})
   let entriesRoot;
   let libraryName;
   let ex = exp || 'named';
+
+  if (showGeneratedComment) {
+    types.push('// File generated automatically by "@scriptappy/to-dts"; DO NOT EDIT.');
+  }
 
   const entries = Object.keys(spec.entries || {});
   const definitions = Object.keys(spec.definitions || {});

--- a/packages/to-dts/test/index.spec.js
+++ b/packages/to-dts/test/index.spec.js
@@ -28,9 +28,7 @@ describe('to-dts', () => {
     typeFn.withArgs({ specification: 'spec' }).returns('getT');
     traverseFn.withArgs({ specification: 'spec', getType: 'getT' }).returns(trav);
 
-    top.withArgs('spec', { umd: undefined, export: undefined, exportConst: undefined }).returns({
-      types: [],
-    });
+    top.withArgs('spec').returns({ types: [] });
 
     toDts('spec');
 
@@ -46,7 +44,7 @@ describe('to-dts', () => {
   it('should return entries', () => {
     const spec = { entries: 'entr' };
 
-    top.withArgs(spec, { umd: undefined, export: undefined, exportConst: undefined }).returns({
+    top.withArgs(spec).returns({
       types: [],
       entriesRoot: 'p',
       entriesFlags: 16,
@@ -65,7 +63,7 @@ describe('to-dts', () => {
   it('should return definitions', () => {
     const spec = { definitions: 'defs' };
 
-    top.withArgs(spec, { umd: undefined, export: undefined, exportConst: undefined }).returns({
+    top.withArgs(spec).returns({
       types: [],
       definitionsRoot: 'defP',
       flags: 0,

--- a/packages/to-dts/test/top.spec.js
+++ b/packages/to-dts/test/top.spec.js
@@ -61,4 +61,13 @@ describe('top', () => {
       },
     });
   });
+
+  it('should include comment that output is generated', () => {
+    expect(top({}, { showGeneratedComment: true })).to.eql({
+      types: ['// File generated automatically by "@scriptappy/to-dts"; DO NOT EDIT.'],
+      entriesRoot: undefined,
+      entriesFlags: 16,
+      definitionsRoot: undefined,
+    });
+  });
 });

--- a/packages/to-dts/test/top.spec.js
+++ b/packages/to-dts/test/top.spec.js
@@ -63,7 +63,7 @@ describe('top', () => {
   });
 
   it('should include comment that output is generated', () => {
-    expect(top({}, { showGeneratedComment: true })).to.eql({
+    expect(top({}, { includeDisclaimer: true })).to.eql({
       types: ['// File generated automatically by "@scriptappy/to-dts"; DO NOT EDIT.'],
       entriesRoot: undefined,
       entriesFlags: 16,


### PR DESCRIPTION
### Overview

Show comment in output file that its content is generated:

```
// File generated automatically by "@scriptappy/to-dts"; DO NOT EDIT.
```

By default the comment is added to the output file. It can be removed using the CLI parameter `includeDisclaimer`. Example:

```
sy to-dts --includeDisclaimer false -o index.d.ts
```

Note; modified how CLI parameters (called `config` in the code) are passed from index.js to top.js in order to make the code less error-prone and tests easier to read and maintain (imho!) 