### PR TITLE
fix(from-jsdoc): include /plugins in published package

### DIFF
--- a/packages/from-jsdoc/package.json
+++ b/packages/from-jsdoc/package.json
@@ -5,6 +5,7 @@
   "main": "publish.js",
   "files": [
     "/lib",
+    "/plugins",
     "spec.config.js"
   ],
   "scripts": {


### PR DESCRIPTION
# Overview

Include files in `/plugins` in the published package.