### PR TITLE
docs: update readme to reflect transitioning to qlik-oss

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The purpose of this project is to define and provide a standard for describing J
 
 ## Examples
 
-- [nodejs](./packages/scriptappy-from-jsdoc/examples/nodejs)
+- [nodejs](./examples/nodejs)
 
 ## Current Version
 
@@ -37,20 +37,16 @@ Current version of the Scriptappy specification is [1.1.0](./packages/scriptappy
 | name                    | status                                                       | description                                 |
 | ----------------------- | ------------------------------------------------------------ | ------------------------------------------- |
 | [scriptappy-schema]     | [![scriptappy-schema-status]][scriptappy-schema-npm]         | JSON Schema of the scriptappy specification |
-| [scriptappy-tools]      | [![scriptappy-tools-status]][scriptappy-tools-npm]           | Tools for schema validation                 |
 | [scriptappy-from-jsdoc] | [![scriptappy-from-jsdoc-status]][scriptappy-from-jsdoc-npm] | Generate a scriptappy definition from JSDoc |
 
 [scriptappy-schema]: https://github.com/qlik-oss/scriptappy/tree/master/packages/scriptappy-schema
-[scriptappy-tools]: https://github.com/qlik-oss/scriptappy/tree/master/packages/scriptappy-tools
-[scriptappy-from-jsdoc]: https://github.com/qlik-oss/scriptappy/tree/master/packages/scriptappy-from-jsdoc
+[scriptappy-from-jsdoc]: https://github.com/qlik-oss/scriptappy/tree/master/packages/from-jsdoc
 [scriptappy-schema-status]: https://img.shields.io/npm/v/scriptappy-schema.svg
-[scriptappy-tools-status]: https://img.shields.io/npm/v/scriptappy-tools.svg
 [scriptappy-from-jsdoc-status]: https://img.shields.io/npm/v/scriptappy-from-jsdoc.svg
-[scriptappy-schema-npm]: https://npmjs.com/package/scriptappy-schema
-[scriptappy-tools-npm]: https://npmjs.com/package/scriptappy-tools
+[scriptappy-schema-npm]: https://npmjs.com/package/@scriptappy/schema
 [scriptappy-from-jsdoc-npm]: https://npmjs.com/package/scriptappy-from-jsdoc
 
 - Markdown API reference documentation (coming soon)
 - Visualize API (coming soon)
   ![Visual API](./assets/visual.png)
-  > A visual representation of [nodejs/scriptappy.json](./packages/scriptappy-from-jsdoc/examples/nodejs/scriptappy.json)
+  > A visual representation of [nodejs/scriptappy.json](./examples/nodejs/scriptappy.json)

--- a/packages/from-jsdoc/README.md
+++ b/packages/from-jsdoc/README.md
@@ -1,4 +1,4 @@
-# scriptappy-from-jsdoc
+# @scriptappy/from-jsdoc
 
 Generate a [Scriptappy](https://github.com/qlik-oss/scriptappy) definition from your JSDoc.
 
@@ -9,7 +9,7 @@ See [nodejs example](./examples/nodejs)
 ## Install
 
 ```sh
-npm install scriptappy-from-jsdoc
+npm install @scriptappy/from-jsdoc @scriptappy/cli
 ```
 
 ## Usage
@@ -17,68 +17,72 @@ npm install scriptappy-from-jsdoc
 ### CLI
 
 ```
-scriptappy-from-jsdoc
+sy from-jsdoc
 
 Options:
   --glob             Glob pattern for source files                                                               [array]
   -c, --config       Path to config file                                                        [string] [default: null]
   -p, --package      Path to package.json                                                                       [string]
   -x                 Output to stdout                                                         [boolean] [default: false]
-  -j, --jsdoc        Path to jsdoc-json file                                                                    [string]
   -o, --output.file  File to write to                                                                           [string]
   -w, --watch        Watch for file changes                                                   [boolean] [default: false]
   -h, --help         Show help                                                                                 [boolean]
   -v, --version      Show version number                                                                       [boolean]
 ```
 
-Running `scriptappy-from-jsdoc` without any arguments will use the default values.
+Running `@scriptappy/from-jsdoc` without any arguments will use the default values.
 
 ```sh
-npx scriptappy-from-jsdoc
+npx @scriptappy/cli from-jsdoc
 ```
 
 More options can be set through a config file:
 
 ```sh
-npx scriptappy-from-jsdoc -c path/to/config.js
+npx @scriptappy/cli from-jsdoc -c path/to/config.js
 ```
 
 ### Configuration
 
 ```js
 module.exports = {
-  glob: ['./src/**/*.js'], // globby patterns to source files
-  package: './package.json', // path to package.json
-  api: { // info about the generated API
-    name: /* string */,
-    description: /* string */,
-    version: /* string */,
-    license: /* string */,
-    stability: /* 'experimental' | 'stable' | 'locked' */,
-  },
-  output: {
-    diffOnly: false, // set to true to write to file only when API has changed
-    file: 'spec.json', // file to write to
-  },
-  jsdoc: /* string | object */, // location of jsdoc-json file, or a jsdoc configuration object
-  spec: {
-    validate: true, // set to false to skip validation against schema, set to 'diff' to validate only when API has changed
-  },
-  parse: {
-    tags: {
-      include: undefined, // an array of white listed tags, e.g. ['committer']
-      exclude: undefined, // an array of black-listed tags (not used if 'include' is an array), e.g. ['owner']
+  fromJsdoc: {
+    glob: ['./src/**/*.js'], // globby patterns to source files
+    package: './package.json', // path to package.json
+    api: { // info about the generated API
+      name: /* string */,
+      description: /* string */,
+      version: /* string */,
+      license: /* string */,
+      stability: /* 'experimental' | 'stable' | 'locked' */,
     },
-    filter(doclet) { return true; },// filter out doclets
-    rules: {
-      'no-unknown-types': 1,
-      'no-missing-types': 1,
-      'no-multi-return': 1,
-      'no-unknown-stability': 2,
-      'no-duplicate-references': 1,
-      'no-untreated-kinds': 1,
-      'no-default-exports-wo-name': 1,
-      'no-unknown-promise': 1,
+    output: {
+      sort: {
+        alpha, // set to true to sort entries and definitions alphabetically
+      },
+      diffOnly: false, // set to true to write to file only when API has changed
+      file: 'spec.json', // file to write to
+    },
+    jsdoc: /* object */, // jsdoc configuration object
+    spec: {
+      validate: true, // set to false to skip validation against schema, set to 'diff' to validate only when API has changed
+    },
+    parse: {
+      tags: {
+        include: undefined, // an array of white listed tags, e.g. ['committer']
+        exclude: undefined, // an array of black-listed tags (not used if 'include' is an array), e.g. ['owner']
+      },
+      filter(doclet) { return true; },// filter out doclets
+      rules: {
+        'no-unknown-types': 1,
+        'no-missing-types': 1,
+        'no-multi-return': 1,
+        'no-unknown-stability': 2,
+        'no-duplicate-references': 1,
+        'no-untreated-kinds': 1,
+        'no-default-exports-wo-name': 1,
+        'no-unknown-promise': 1,
+      }
     }
   }
 }
@@ -89,25 +93,3 @@ module.exports = {
 Parsing rules work a lot like [eslint rules](https://eslint.org/docs/rules/) and are meant to warn/error when weirds things are found in the jsdoc comments.
 
 [More details on rules](./docs/rules.md).
-
-### Generating definition from a JSDoc-JSON file
-
-`scriptappy-from-jsdoc` will by default create a jsdoc-json file on the fly using the specified `glob` pattern. If you already have a jsdoc-json file, you can pass that in in two ways:
-
-#### Pipe output from jsdoc to scriptappy-from-jsdoc
-
-```sh
-npx jsdoc src -r -X | scriptappy-from-jsdoc
-```
-
-`npx jsdoc src -r` generates documentation from files found in `./src` and its subfolders.
-
-`-X` flag writes jsdoc-json to stdout, which is then piped to scriptappy-from-jsdoc.
-
-#### Use scriptappy-from-jsdoc as template
-
-```sh
-npx jsdoc src -r -t scriptappy-from-jsdoc
-```
-
-`-t`specifies `scriptappy-from-jsdoc` as the output template for `jsdoc`.

--- a/packages/scriptappy-schema/README.md
+++ b/packages/scriptappy-schema/README.md
@@ -5,5 +5,5 @@ A specification for Javascript APIs
 ## Install
 
 ```sh
-npm install scriptappy-schema
+npm install @scriptappy/schema
 ```


### PR DESCRIPTION
# Overview

Update README.md files to reflect the transition to qlik-oss. It includes:

* Use `@scriptappy/<pkg>` when installing / referencing the packages
* Use `sy <cmd>` to run scriptappy packages, e.g. `sy from-jsdoc`
* Update options to match source code, e.g. JSDoc is always run in package from-jsdoc so no longer any option to pass a reference to a JSDoc json file