### PR TITLE
feat(to-dts): use declare function and const for api entries

### DIFF
--- a/packages/to-dts/lib/traverse.js
+++ b/packages/to-dts/lib/traverse.js
@@ -74,7 +74,15 @@ function traverseFn(g) {
       }
 
       if (def.entries) {
-        arr.push(...g.traverse(def.entries, { parent: tsType, path: `${p}/entries`, flags: 0 }));
+        if (def.kind === 'function') {
+          const ns = dom.create.namespace(key);
+          if (flags) {
+            ns.flags = flags | (tsType.flags || 0);
+          }
+          arr.push(ns, ...g.traverse(def.entries, { parent: ns, path: `${p}/entries`, flags: 0 }));
+        } else {
+          arr.push(...g.traverse(def.entries, { parent: tsType, path: `${p}/entries`, flags: 0 }));
+        }
       }
       if (def.staticEntries) {
         arr.push(

--- a/packages/to-dts/lib/types/function.js
+++ b/packages/to-dts/lib/types/function.js
@@ -2,32 +2,17 @@
 const dom = require('dts-dom');
 const params = require('./params');
 
-module.exports = function fn(def, tsParent, g) {
+module.exports = function fn(def, tsParent, g, isEntry) {
   const par = params(def.params || [], def.this, g);
   const ret = def.returns ? g.getType(def.returns) : dom.type.void;
+  if (isEntry) {
+    return dom.create.function(def.name, par, ret);
+  }
   if (tsParent && ['class', 'interface', 'object'].includes(tsParent.kind)) {
     return dom.create.method(def.name, par, ret);
   }
   if (tsParent && ['union', 'array', 'parameter', 'alias'].includes(tsParent.kind)) {
     return dom.create.functionType(par, ret);
-  }
-  if (def.entries) {
-    const t = dom.create.objectType([]);
-    const cs = dom.create.callSignature(par, ret);
-
-    // optional/rest flags for params in call-signatures are NOT printed by dts-dom,
-    // so hack it a bit by ammending ... or ? to the name of the param to get the same effect
-    // TODO - remove this hack when dts-dom fixes this
-    cs.parameters.forEach(p => {
-      if ((p.flags || 0) & dom.ParameterFlags.Optional) {
-        p.name += '?';
-      } else if (p.flags === dom.ParameterFlags.Rest) {
-        p.name = `...${p.name}`;
-      }
-      p.flags = 0; // reset to avoid flags being used if dts-dom supports it before above code has been removed
-    });
-    t.members.push(cs);
-    return t;
   }
 
   // TODO - async?

--- a/packages/to-dts/lib/types/function.js
+++ b/packages/to-dts/lib/types/function.js
@@ -5,14 +5,14 @@ const params = require('./params');
 module.exports = function fn(def, tsParent, g, isEntry) {
   const par = params(def.params || [], def.this, g);
   const ret = def.returns ? g.getType(def.returns) : dom.type.void;
-  if (isEntry) {
-    return dom.create.function(def.name, par, ret);
-  }
   if (tsParent && ['class', 'interface', 'object'].includes(tsParent.kind)) {
     return dom.create.method(def.name, par, ret);
   }
   if (tsParent && ['union', 'array', 'parameter', 'alias'].includes(tsParent.kind)) {
     return dom.create.functionType(par, ret);
+  }
+  if (isEntry) {
+    return dom.create.function(def.name, par, ret);
   }
 
   // TODO - async?

--- a/packages/to-dts/lib/types/reference.js
+++ b/packages/to-dts/lib/types/reference.js
@@ -1,16 +1,22 @@
 const dom = require('dts-dom');
 
 const DEF_RX = /^#\/definitions\//;
-module.exports = function ref(path, tsParent, g) {
+module.exports = function ref(path, name, g, isEntry) {
   const p = path
     .split('/')
     .slice(1)
     .filter((a, i) => i % 2 !== 0)
     .join('.');
 
-  if (g.namespace && DEF_RX.test(path)) {
-    return dom.create.namedTypeReference(`${g.namespace}.${p}`);
+  // API entry
+  if (isEntry) {
+    return dom.create.const(name, [g.namespace, p].filter(Boolean).join('.'));
   }
-
-  return dom.create.namedTypeReference(p);
+  // Definition ref
+  if (DEF_RX.test(path)) {
+    return dom.create.namedTypeReference([g.namespace, p].filter(Boolean).join('.'));
+  }
+  // Entry ref
+  const typeRef = dom.create.namedTypeReference(p);
+  return dom.create.typeof(typeRef);
 };

--- a/packages/to-dts/test/function.spec.js
+++ b/packages/to-dts/test/function.spec.js
@@ -50,6 +50,13 @@ describe('function', () => {
     });
   });
 
+  it('should create as function for api entry', () => {
+    const def = {};
+    params.returns([]);
+    const type = fn(def, { kind: 'namespace' }, {}, true);
+    expect(type.kind).to.eql('function');
+  });
+
   it('should have params', () => {
     const def = {
       params: 'par',

--- a/packages/to-dts/test/reference.spec.js
+++ b/packages/to-dts/test/reference.spec.js
@@ -7,6 +7,8 @@ describe('reference', () => {
     dom = {
       create: {
         namedTypeReference: v => v,
+        const: (name, type) => `const ${name}: ${type}`,
+        typeof: v => `typeof ${v}`,
       },
     };
 
@@ -18,18 +20,22 @@ describe('reference', () => {
   });
 
   it('should return just the first level', () => {
-    expect(ref('#/entries/Animal', false, {})).to.eql('Animal');
+    expect(ref('#/entries/Animal', undefined, {}, false)).to.eql('typeof Animal');
   });
 
   it('should ignore every other level', () => {
-    expect(ref('#/entries/Animal/definitions/Dog', false, {})).to.eql('Animal.Dog');
+    expect(ref('#/entries/Animal/definitions/Dog', undefined, {}, false)).to.eql('typeof Animal.Dog');
   });
 
   it('should return without namespace prefix when top path is entries', () => {
-    expect(ref('#/entries/Animal', false, { namespace: 'farm' })).to.eql('Animal');
+    expect(ref('#/entries/Animal', undefined, { namespace: 'farm' }, false)).to.eql('typeof Animal');
   });
 
   it('should return with namespace prefix when top path is definitions', () => {
-    expect(ref('#/definitions/Animal', false, { namespace: 'farm' })).to.eql('farm.Animal');
+    expect(ref('#/definitions/Animal', undefined, { namespace: 'farm' }, false)).to.eql('farm.Animal');
+  });
+
+  it('should return `const name: type` for API entries', () => {
+    expect(ref('#/definitions/Embed', 'embed', { namespace: 'Stardust' }, true)).to.eql('const embed: Stardust.Embed');
   });
 });

--- a/packages/to-dts/test/type.spec.js
+++ b/packages/to-dts/test/type.spec.js
@@ -55,8 +55,8 @@ describe('type', () => {
 
   it('should create reference', () => {
     const def = { type: '#/' };
-    reference.withArgs(def.type, 'p').returns('ref');
-    expect(getType(def, 'p')).to.eql('ref');
+    reference.withArgs(def.type).returns('ref');
+    expect(getType(def)).to.eql('ref');
   });
 
   it('should create module', () => {
@@ -202,6 +202,20 @@ describe('type', () => {
       prim => {
         const def = { type: prim };
         expect(getType(def, 'p')).to.eql(prim);
+      }
+    );
+  });
+
+  it('should create value (`const name: type`) for known ts type in api entries', () => {
+    ['string', 'number', 'boolean', 'any', 'void', 'object', 'null', 'undefined', 'true', 'false', 'this'].forEach(
+      prim => {
+        const def = { type: prim, name: 'version', path: '#/entries/embed' };
+        expect(getType(def)).to.eql({
+          kind: 'const',
+          name: 'version',
+          type: prim,
+          flags: 0,
+        });
       }
     );
   });


### PR DESCRIPTION
# Overview

Functions and variables for entries exported in the API uses `function` and `const`, i.e. values. Previously the type definitions were exposed (e.g. `interface`).

## Properties on API functions

Functions exposed in the API are exported as functions, e.g. `export function embed(): stardust.Embed`. Properties are added using a namespace with the same name as the function.

Example:

```ts
export function embed(app: EngineAPI.IApp, instanceConfig?: stardust.Configuration): stardust.Embed;

export namespace embed {
    function createConfiguration(configuration: stardust.Configuration): typeof embed;
    const version: string;
}

declare namespace stardust {
    ...
}
```

## Referencing API functions

When referencing a function exposed in the API it uses `typeof` to get the definition. Example:

```
function createConfiguration(configuration: stardust.Configuration): typeof embed;
```

## Example type defs with changes in PR
[picasso.js](https://gist.github.com/streamside/097896a8ec676c3ed60c40eec9b069b9)
[@nebula.js/stardust](https://gist.github.com/streamside/c625101902aa1ff3e105e929fa46c8a3)