### PR TITLE
chore(to-dts): remove exportConst option from cli

### DIFF
--- a/packages/to-dts/lib/cli.js
+++ b/packages/to-dts/lib/cli.js
@@ -23,10 +23,6 @@ const toDts = {
         describe: 'Type of export',
         type: 'string',
       },
-      exportConst: {
-        description: 'Create const of generated type to export',
-        type: 'string',
-      },
       output: {
         alias: 'o',
         describe: 'File to write to',

--- a/packages/to-dts/lib/index.js
+++ b/packages/to-dts/lib/index.js
@@ -11,7 +11,6 @@ const top = require('./top');
  * @param {object=} config
  * @param {string=} config.umd
  * @param {('named'|'exports'|'default')=} config.export
- * @param {string=} config.exportConst
  * @param {string=} config.output
  * @param {boolean=} config.includeDisclaimer
  * @returns {string}

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -36,7 +36,7 @@ module.exports = function top(spec, { umd = '', export: exp, includeDisclaimer }
     libraryName = n;
   }
 
-  const nsName = libraryName.charAt(0).toUpperCase() + libraryName.slice(1);
+  const nsName = libraryName && libraryName.charAt(0).toUpperCase() + libraryName.slice(1);
   const definitionsRoot = definitions.length ? dom.create.namespace(nsName) : undefined;
 
   // "export = x" is used for commonjs modules of type "module.exports = x"

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -36,7 +36,8 @@ module.exports = function top(spec, { umd = '', export: exp, exportConst, includ
     libraryName = n;
   }
 
-  const definitionsRoot = definitions.length ? dom.create.namespace(libraryName) : undefined;
+  const nsName = libraryName.charAt(0).toUpperCase() + libraryName.slice(1);
+  const definitionsRoot = definitions.length ? dom.create.namespace(nsName) : undefined;
 
   // "export = x" is used for commonjs modules of type "module.exports = x"
   // "export default x" is used for es6 modules of type "export default x"

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -1,6 +1,6 @@
 const dom = require('dts-dom');
 
-module.exports = function top(spec, { umd = '', export: exp, exportConst, includeDisclaimer } = {}) {
+module.exports = function top(spec, { umd = '', export: exp, includeDisclaimer } = {}) {
   // dom.create.namespace('supernova');
   const types = [];
   let entriesFlags = 0;
@@ -43,12 +43,7 @@ module.exports = function top(spec, { umd = '', export: exp, exportConst, includ
   // "export default x" is used for es6 modules of type "export default x"
   // "export x" is for named exports
   if (ex === 'default') {
-    if (exportConst) {
-      types.push(dom.create.const(exportConst, libraryName));
-      types.push(dom.create.exportDefault(exportConst));
-    } else {
-      types.push(dom.create.exportDefault(libraryName));
-    }
+    types.push(dom.create.exportDefault(libraryName));
   } else if (ex === 'exports') {
     types.push(dom.create.exportEquals(libraryName));
   } else {

--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -36,8 +36,7 @@ module.exports = function top(spec, { umd = '', export: exp, includeDisclaimer }
     libraryName = n;
   }
 
-  const nsName = libraryName && libraryName.charAt(0).toUpperCase() + libraryName.slice(1);
-  const definitionsRoot = definitions.length ? dom.create.namespace(nsName) : undefined;
+  const definitionsRoot = definitions.length ? dom.create.namespace(libraryName) : undefined;
 
   // "export = x" is used for commonjs modules of type "module.exports = x"
   // "export default x" is used for es6 modules of type "export default x"

--- a/packages/to-dts/scriptappy.json
+++ b/packages/to-dts/scriptappy.json
@@ -41,10 +41,6 @@
                 }
               ]
             },
-            "exportConst": {
-              "optional": true,
-              "type": "string"
-            },
             "output": {
               "optional": true,
               "type": "string"

--- a/packages/to-dts/test/top.spec.js
+++ b/packages/to-dts/test/top.spec.js
@@ -57,7 +57,7 @@ describe('top', () => {
       definitionsRoot: {
         kind: 'namespace',
         members: [],
-        name: 'MyLib',
+        name: 'myLib',
       },
     });
   });

--- a/packages/to-dts/test/top.spec.js
+++ b/packages/to-dts/test/top.spec.js
@@ -57,7 +57,7 @@ describe('top', () => {
       definitionsRoot: {
         kind: 'namespace',
         members: [],
-        name: 'myLib',
+        name: 'MyLib',
       },
     });
   });


### PR DESCRIPTION
# Overview

## Remove `--exportConst` from CLI

As the value is exported due to change in [PR](https://github.com/qlik-oss/scriptappy/pull/51) the CLI option `--exportConst` is rendered obsolete. 