### PR TITLE
feat: add NamedNodeMap as a known type for web

### DIFF
--- a/packages/from-jsdoc/lib/types.js
+++ b/packages/from-jsdoc/lib/types.js
@@ -6,6 +6,7 @@ const web = [
   'HTMLElement',
   'Element',
   'Event',
+  'NamedNodeMap',
 ];
 
 // TODO - expand the list


### PR DESCRIPTION
# Overview

Add `NamedNodeMap` as a known type for web. It will result in that no warning about unknown type will be displayed when generating api specifications from JSDoc for this type.