### PR TITLE
fix: mark object with kind not type

### DIFF
--- a/packages/from-jsdoc/lib/check-types.js
+++ b/packages/from-jsdoc/lib/check-types.js
@@ -42,6 +42,10 @@ function checkTypes(obj, priv, cfg, scopeTypes = []) {
         cfg.logRule(null, 'no-unknown-types', `Type unknown: '${prop.type}'`);
       }
     }
+    if (prop.type === 'object' && prop.entries) {
+      delete prop.type;
+      prop.kind = 'object';
+    }
 
     checkTypes(prop, priv, cfg, st);
   });


### PR DESCRIPTION
improved (alternate) version of the fix in #97