### PR TITLE
fix: extract type from comment

### DIFF
--- a/packages/from-jsdoc/lib/type-parser.js
+++ b/packages/from-jsdoc/lib/type-parser.js
@@ -117,12 +117,12 @@ const extractTypeFromRx = (rx, comment) => {
 };
 
 const getParamFromComment = (name, c) => {
-  const rx = new RegExp(`^\\s*\\*\\s*@param\\s+(.*)\\s*${name}`);
+  const rx = new RegExp(`^\\s*\\*\\s*@param\\s+({.*})\\s*${name}`);
   return extractTypeFromRx(rx, c);
 };
 
 const getPropertyFromComment = (name, c) => {
-  const rx = new RegExp(`^\\s*\\*\\s*@property\\s+(.*)\\s*${name}`);
+  const rx = new RegExp(`^\\s*\\*\\s*@property\\s+({.*})\\s*${name}`);
   return extractTypeFromRx(rx, c);
 };
 

--- a/packages/from-jsdoc/test/type-parser.spec.js
+++ b/packages/from-jsdoc/test/type-parser.spec.js
@@ -14,6 +14,17 @@ describe('type-parser', () => {
       expect(getPropertyFromComment('pro.oo', c)).to.equal('{blapar.foopar.o}');
     });
 
+    it('color property', () => {
+      const c = `/**
+      * Color information structure. Holds the actual color and index in palette.
+      * @interface paletteColor
+      * @property {string} color - Color as hex string (mandatory if index: -1)
+      * @property {number} index - Index in palette
+      */`;
+
+      expect(getPropertyFromComment('index', c)).to.equal('number');
+    });
+
     it('return', () => {
       const c = '/**\n * @return {{blapar.foopar.o}} bla */';
       expect(getReturnFromComment(c)).to.equal('{blapar.foopar.o}');


### PR DESCRIPTION
extract correct type when property name is included in comment for other property