### PR TITLE
chore: add support for dts imports

### DIFF
--- a/packages/to-dts/lib/top.js
+++ b/packages/to-dts/lib/top.js
@@ -19,6 +19,12 @@ module.exports = function top(spec, { umd = '', export: exp, includeDisclaimer, 
     });
   }
 
+  if (Array.isArray(dependencies.imports)) {
+    dependencies.imports.forEach((imp) => {
+      types.push(`import ${imp.type} from ${imp.package};`);
+    });
+  }
+
   const entries = Object.keys(spec.entries || {});
   const definitions = Object.keys(spec.definitions || {});
   if (entries.length === 1) {


### PR DESCRIPTION
Adds support for external typescript imports in the generated spec file:
```
  toDts: {
    spec: './api-spec/spec.json',
    output: {
      file: './types/index.d.ts',
    },
    dependencies: {
      references: ['someTypes'],
      imports: [{ type: '* as qix', package: '@qlik/api/qix' }],
    },
  },
```